### PR TITLE
Don't run install phase while generating docs

### DIFF
--- a/src/doc-proto.nix
+++ b/src/doc-proto.nix
@@ -9,4 +9,5 @@ pkgs.stdenv.mkDerivation {
     mkdir $out;
     protoc --plugin=${pkgs.protoc-gen-doc}/bin/protoc-gen-doc ${builtins.concatStringsSep " " protos} --doc_out=$out --doc_opt=${docType},api.md;
   '';
+  installPhase = "";
 }


### PR DESCRIPTION
Otherwise `stdenv.mkDerivation` will try to execute `make install` in the default install phase when it see a `Makefile` in `src`.