### PR TITLE
don't run default install phase while generating docs

### DIFF
--- a/src/doc-proto.nix
+++ b/src/doc-proto.nix
@@ -9,4 +9,5 @@ pkgs.stdenv.mkDerivation {
     mkdir $out;
     protoc --plugin=${pkgs.protoc-gen-doc}/bin/protoc-gen-doc ${builtins.concatStringsSep " " protos} --doc_out=$out --doc_opt=${docType},api.md;
   '';
+  dontInstall = true;
 }

--- a/src/doc-proto.nix
+++ b/src/doc-proto.nix
@@ -9,5 +9,4 @@ pkgs.stdenv.mkDerivation {
     mkdir $out;
     protoc --plugin=${pkgs.protoc-gen-doc}/bin/protoc-gen-doc ${builtins.concatStringsSep " " protos} --doc_out=$out --doc_opt=${docType},api.md;
   '';
-  installPhase = "";
 }


### PR DESCRIPTION
With the correct fix this time around. Sorry for the inconvenience.